### PR TITLE
replace outdated link to flag test with permalink

### DIFF
--- a/tests/graph.test.ts
+++ b/tests/graph.test.ts
@@ -1,4 +1,4 @@
-// https://github.com/preactjs/signals/blob/main/packages/core/test/signal.test.tsx#L1249
+// https://github.com/preactjs/signals/blob/17c0155997f47f4bb81e5715b46a55d1fafa22a2/packages/core/test/signal.test.tsx#L1383
 
 import { createMemo, createSignal } from "../src/index.js";
 


### PR DESCRIPTION
the link became outdated so this PR replaces it with a permalink so it doesn't happen again